### PR TITLE
Tests with fixture

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,7 @@
 [bdist_wheel]
 universal=1
+
+[flake8]
+# For error codes, see
+# http://pep8.readthedocs.org/en/latest/intro.html#error-codes
+max-line-length = 85

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from setuptools import setup, find_packages
 
 desc = ''

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import textwrap
 
 
 # Default test dir:
-PIKE_TEST_DIR='pike_tests'
+PIKE_TEST_DIR = 'pike_tests'
 
 
 # ------------------------------------------------------------
@@ -38,8 +38,8 @@ def pike_tmp_package(pike_init_py):
 
        :param pike_init_py: fixture with py.path.local object pointing to
                             directory with empty __init__.py
-       :return: temporary directory path to the package (containing __init__.py,
-                app.py, and more.py)
+       :return: temporary directory path to the package (containing
+                __init__.py,  app.py, and more.py)
 
        HINT: Usually you can find the temporary directory under
              /tmp/pytest-of-$USER/pytest-$NUMBER/$NAME_OF_TEST_FUNCTION/

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,3 @@
-#
-#
-#
 
 import pytest
 import textwrap

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,61 @@
+#
+#
+#
+
+import pytest
+import textwrap
+
+
+# Default test dir:
+PIKE_TEST_DIR='pike_tests'
+
+
+# ------------------------------------------------------------
+# Fixtures
+#
+# See http://pytest.org/latest/tmpdir.html
+
+@pytest.fixture
+def pike_init_py(tmpdir):
+    """Fixture: Create a directory with an empty __init__.py
+       inside a temporary directory
+
+       :param tmpdir: fixture with py.path.local object
+       :return: temporary directory path to __init__.py
+
+       HINT: Usually you can find the temporary directory under
+             /tmp/pytest-of-$USER/pytest-$NUMBER/$NAME_OF_TEST_FUNCTION/
+    """
+    pkgdir = tmpdir.mkdir(PIKE_TEST_DIR)
+    (pkgdir / "__init__.py").write("")
+    return pkgdir
+
+
+@pytest.fixture
+def pike_tmp_package(pike_init_py):
+    """Fixture: Create a Python package inside a temporary directory.
+       Depends on the pike_init_py fixture
+
+       :param pike_init_py: fixture with py.path.local object pointing to
+                            directory with empty __init__.py
+       :return: temporary directory path to the package (containing __init__.py,
+                app.py, and more.py)
+
+       HINT: Usually you can find the temporary directory under
+             /tmp/pytest-of-$USER/pytest-$NUMBER/$NAME_OF_TEST_FUNCTION/
+    """
+    # First file:
+    (pike_init_py / 'app.py').write(textwrap.dedent("""
+        class SampleObj(object):
+            pass
+
+        class OtherObj(SampleObj):
+            pass
+        """))
+
+    # Second file:
+    (pike_init_py / 'more.py').write(textwrap.dedent("""
+        class AnotherObj(object):
+            pass
+        """))
+    return pike_init_py

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -78,7 +78,6 @@ class TestManager(object):
 
         assert len(classes) == 3
 
-
     def test_get_classes_with_fixtures(self, pike_tmp_package):
         """Structurally the same than test_get_classes, but with fixtures
            (see conftest.py)
@@ -88,7 +87,6 @@ class TestManager(object):
             classes = mgr.get_classes()
 
         assert len(classes) == 3
-
 
     def test_get_inherited_classes(self):
         temp_folder = utils.make_tmpdir()
@@ -120,7 +118,6 @@ class TestManager(object):
             classes = mgr.get_all_inherited_classes(app.SampleObj)
 
         assert len(classes) == 1
-
 
     def test_get_inherited_classes_with_fixtures(self, pike_tmp_package):
         """Structurally the same than test_get_inherited_classes, but with fixtures

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -78,6 +78,18 @@ class TestManager(object):
 
         assert len(classes) == 3
 
+
+    def test_get_classes_with_fixtures(self, pike_tmp_package):
+        """Structurally the same than test_get_classes, but with fixtures
+           (see conftest.py)
+        """
+        classes = []
+        with PikeManager([str(pike_tmp_package)]) as mgr:
+            classes = mgr.get_classes()
+
+        assert len(classes) == 3
+
+
     def test_get_inherited_classes(self):
         temp_folder = utils.make_tmpdir()
         pkg_name = 'pike_mgr_inherited_classes'
@@ -104,6 +116,21 @@ class TestManager(object):
 
         classes = []
         with PikeManager([temp_folder]) as mgr:
+            app = py.get_module_by_name('{}.app'.format(pkg_name))
+            classes = mgr.get_all_inherited_classes(app.SampleObj)
+
+        assert len(classes) == 1
+
+
+    def test_get_inherited_classes_with_fixtures(self, pike_tmp_package):
+        """Structurally the same than test_get_inherited_classes, but with fixtures
+           (see conftest.py)
+        """
+        # Actually, this is not really needed.
+        pkg_name = 'pike_mgr_inherited_classes'
+        pike_tmp_package.rename(pike_tmp_package.dirpath() / pkg_name)
+        classes = []
+        with PikeManager([pike_tmp_package.dirname]) as mgr:
             app = py.get_module_by_name('{}.app'.format(pkg_name))
             classes = mgr.get_all_inherited_classes(app.SampleObj)
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,4 +9,5 @@ commands =
     coverage report -m
 
 [testenv:flake8]
-commands = flake8
+commands =
+    flake8 --statistics -j auto --count pike tests


### PR DESCRIPTION
Hi John, :wave: 

this is a friendly PR to show you the power of fixtures (and `py.path.local`, an OO approach to access files). I've tested it on Python 2.7 and 3.4 and it worked for me.

I hope I was able to show you some benefits of this PR. Here are some of my thoughts:
- With the help of fixtures, you can shorten your test cases tremendously. Compare in `test_manager.py` the functions `test_get_classes_with_fixtures` vs `test_get_classes` and `test_get_inherited_classes_with_fixtures` vs `test_get_inherited_classes`.
- IMHO the `utils.py` file is mostly unnecessary and can be replaced by fixtures. This is not done yet, but it is probably quite easy to do.
- The `py.path.local` object is also quite powerful. You don't need to fiddle around with `os.path.*` and the like. That makes your code also quite compact.
- The PR is not complete nor exhaustive. It was just a "proof-of-concept".

I took also the freedom to make some changes in regards to flake and tox. They are tiny, but I put them in a separate commit.

Hope this gives you some inspiration on how to reduce your code for test cases. Maybe you like it. :smiley: 
