### PR TITLE
Pytest: finder fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,12 +3,21 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# Editor
+*.kate-swp
+*.~
+*~
+*.swp
+.idea
+
 # C extensions
 *.so
 
 # Distribution / packaging
 .Python
 env/
+.env2/
+.env3/
 build/
 develop-eggs/
 dist/

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,23 @@ universal=1
 # For error codes, see
 # http://pep8.readthedocs.org/en/latest/intro.html#error-codes
 max-line-length = 85
+
+[pytest]
+norecursedirs =
+    .git
+    .tox
+    .env2
+    .env3
+    .tmp
+    dist
+    build
+addopts =
+    -rxEfsw
+    --strict
+    --ignore=docs/conf.py
+    --ignore=test-requirements.txt
+    --ignore=tests/conftest.py
+    --ignore=setup.py
+    --ignore=.env2
+    --ignore=.env3
+    --doctest-modules

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
 
 import pytest
 import textwrap
+from py.path import local
+
+from pike.finder import PikeFinder
 
 
 # Default test dir:
@@ -11,6 +14,16 @@ PIKE_TEST_DIR = 'pike_tests'
 # Fixtures
 #
 # See http://pytest.org/latest/tmpdir.html
+
+@pytest.fixture
+def pike_finder():
+    """Fixture: Return PikeFinder object
+
+    :return: PikeFinder object
+    """
+    finder_path = local(__file__).dirpath().dirpath()
+    return PikeFinder([str(finder_path)])
+
 
 @pytest.fixture
 def pike_init_py(tmpdir):

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -1,30 +1,24 @@
 import os
 
-from pike.finder import PikeFinder
+
+def test_module_name_to_filename(pike_finder):
+    res = pike_finder.module_name_to_filename('pike.finder')
+    assert res == 'pike{0}finder'.format(os.path.sep)
 
 
-class TestFinder(object):
-    def setup_method(self, method):
-        partial_path, _ = os.path.split(__file__)
-        finder_path, _ = os.path.split(partial_path)
-        self.finder = PikeFinder([finder_path])
+def test_get_import_filename_module(pike_finder):
+    filename = pike_finder.module_name_to_filename('tests.test_finder')
+    module_path = pike_finder.get_import_filename(filename)
+    assert module_path == __file__
 
-    def test_module_name_to_filename(self):
-        res = self.finder.module_name_to_filename('pike.finder')
-        assert res == 'pike{0}finder'.format(os.path.sep)
 
-    def test_get_import_filename_module(self):
-        filename = self.finder.module_name_to_filename('tests.test_finder')
-        module_path = self.finder.get_import_filename(filename)
+def test_get_import_filename_package(pike_finder):
+    filename = pike_finder.module_name_to_filename('tests')
+    module_path = pike_finder.get_import_filename(filename)
 
-        assert module_path == __file__
+    assert module_path.endswith('tests{0}__init__.py'.format(os.path.sep))
 
-    def test_get_import_filename_package(self):
-        filename = self.finder.module_name_to_filename('tests')
-        module_path = self.finder.get_import_filename(filename)
 
-        assert module_path.endswith('tests{0}__init__.py'.format(os.path.sep))
-
-    def test_no_loader_returned_if_module_not_in_scope(self):
-        loader = self.finder.find_module('bam')
-        assert not loader
+def test_no_loader_returned_if_module_not_in_scope(pike_finder):
+    loader = pike_finder.find_module('bam')
+    assert not loader


### PR DESCRIPTION
Hi John,

this is a more "radical" rewrote of the `TestFinder` class. Actually, the class isn't really needed in pytest; the `setup_method()` can be completely replaced with the `pike_finder` fixture (see `conftest.py`).

However, if you like, it is also possible to define setup functions on a module or file level.

I kept your function names. ;-)

Let me know what you think.
